### PR TITLE
[GBPAY-3590] Add mockServiceClientCall

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -1,10 +1,12 @@
 import request from 'supertest';
-import type { Service, ServiceStartOptions } from '@gasbuddy/service';
+import { createServiceClientInterface, type Service, type ServiceStartOptions } from '@gasbuddy/service';
 import {
-  getReusableApp, clearReusableApp, mockServiceCall, getExistingApp,
+  getReusableApp, clearReusableApp, getExistingApp,
+  mockServiceClientCall,
 } from '../src';
 
 import { FakeServLocals } from './src/types';
+import { FakeServImpl } from './src';
 
 function getFakeServiceFn(flags: {
   started: number;
@@ -12,13 +14,11 @@ function getFakeServiceFn(flags: {
 }): () => Service<FakeServLocals> {
   return () => ({
     start(app) {
-      app.locals.services = {
-        fakeServ: {
-          async get_something() {
-            throw new Error('Should not be called.');
-          },
+      Object.assign(app.locals, {
+        services: {
+          fakeServ: createServiceClientInterface<FakeServImpl>('fake-serv', FakeServImpl),
         },
-      };
+      });
       flags.started += 1;
     },
     async stop() {
@@ -57,9 +57,15 @@ describe('Start and stop shared app', () => {
     await request(app).get('/').expect(200);
     await request(app).get('/foobar').expect(404);
     await request(app).post('/').expect(500);
-    mockServiceCall(app.locals.services.fakeServ, 'get_something').mockResolvedValue({
-      body: { things: ['a', 'b', 'c'] },
-    });
+    app.locals.services.fakeServ = jest.fn().mockImplementation(() => ({
+      getSomething() {
+        return {
+          body: {
+            things: ['a', 'b', 'c'],
+          },
+        };
+      },
+    }));
     const { body } = await request(app).post('/').expect(200);
     expect(body.things).toBeTruthy();
     expect(body.things.length).toEqual(3);

--- a/__tests__/src/index.ts
+++ b/__tests__/src/index.ts
@@ -1,7 +1,26 @@
-import { Service } from '@gasbuddy/service';
+import { createServiceClientInterface, Service, ServiceExpress } from '@gasbuddy/service';
+
+export class FakeServImpl {
+  app: ServiceExpress | undefined;
+
+  constructor(app: any) {
+    this.app = app;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getSomething() {
+    throw new Error('Should not be called.');
+  }
+}
 
 export default function (): Service {
   return {
-    start() {},
+    start(app) {
+      Object.assign(app.locals, {
+        services: {
+          fakeServ: createServiceClientInterface<FakeServImpl>('fake-serv', FakeServImpl),
+        },
+      });
+    },
   };
 }

--- a/__tests__/src/routes/index.ts
+++ b/__tests__/src/routes/index.ts
@@ -7,7 +7,8 @@ export default function route(router: ServiceRouter<FakeServLocals>) {
   });
 
   router.post('/', async (req, res) => {
-    const { body } = await req.app.locals.services.fakeServ.get_something();
+    const { fakeServ } = req.app.locals.services;
+    const { body } = await fakeServ(req.app).getSomething();
     res.json(body);
   });
 }

--- a/__tests__/src/types.ts
+++ b/__tests__/src/types.ts
@@ -1,10 +1,10 @@
-import { ServiceLocals } from '@gasbuddy/service';
+import { ServiceLocals, ServiceExpress } from '@gasbuddy/service';
 import { RestApiErrorResponse, RestApiSuccessResponse } from 'rest-api-support';
 
 export interface FakeServLocals extends ServiceLocals {
   services: {
-    fakeServ: {
-      get_something(): Promise<RestApiSuccessResponse<{ things: string[] }> | RestApiErrorResponse>;
-    }
-  }
+    fakeServ: (app: ServiceExpress) => {
+      getSomething(): Promise<RestApiSuccessResponse<{ things: string[] }> | RestApiErrorResponse>;
+    },
+  },
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import path from 'path';
+import fs from 'fs';
 import readPackageUp from 'read-pkg-up';
 import { shutdownApp, startApp } from '@gasbuddy/service';
 
@@ -36,6 +37,7 @@ async function readOptions<
 ): Promise<ServiceStartOptions<SLocals, RLocals>> {
   const isServiceFn = typeof options === 'function';
   let factory = isServiceFn ? options : options.service;
+  let useJsEntrypoint = false;
   const rootDirectory = await getRootDirectory(
     cwd,
     isServiceFn ? undefined : options?.rootDirectory,
@@ -52,8 +54,12 @@ async function readOptions<
     if (finalOptions.codepath === 'src') {
       main = main.replace(/^(\.?\/?)build\//, '$1src/').replace(/\.js$/, '.ts');
     }
+    let finalPath = path.resolve(rootDirectory, main);
+    if (!fs.existsSync(finalPath)) {
+      finalPath = finalPath.replace('.ts', '.js');
+      useJsEntrypoint = true;
+    }
     if (!factory) {
-      const finalPath = path.resolve(rootDirectory, main);
       // eslint-disable-next-line import/no-dynamic-require, global-require
       const module = require(finalPath);
       factory = (module.default || module.service) as () => Service<SLocals, RLocals>;
@@ -69,6 +75,7 @@ async function readOptions<
     name,
     ...finalOptions,
     service: factory,
+    useJsEntrypoint,
   };
 }
 
@@ -142,6 +149,12 @@ export async function getSimulatedContext(config?: Record<string, any>) {
   };
 }
 
+/**
+ * @param service The service to mock
+ * @param method The method to mock
+ * @returns mocks for the service method
+ * @deprecated Use mockServiceClientCall instead
+ */
 export function mockServiceCall<
   TargetService extends {},
   M extends keyof jest.FunctionProperties<Required<TargetService>>,
@@ -179,9 +192,47 @@ export function mockServiceCall<
   };
 }
 
+export function mockServiceClientCall<
+  TargetService extends {},
+  M extends keyof jest.FunctionProperties<Required<TargetService>>,
+>(serviceFn: (service: ServiceExpress) => TargetService, method: M) {
+  const client = serviceFn(<ServiceExpress>app);
+  const spy = jest.spyOn(client, method);
+  // I feel like Typescript should've been able to figure this out,
+  // but I couldn't get it to and neither could the Interwebs. So a slightly
+  // unsafe cast it is.
+  type ResponseType = Parameters<typeof spy['mockResolvedValue']>[0];
+  return {
+    mockResolvedValue: (sim: Partial<ResponseType>) => spy.mockResolvedValue({
+      responseType: 'response',
+      status: 200,
+      ...sim,
+      headers: new Headers(sim.headers || {}),
+    } as ResponseType),
+    mockResolvedValueOnce: (sim: Partial<ResponseType>) => spy.mockResolvedValueOnce({
+      responseType: 'response',
+      status: 200,
+      ...sim,
+      headers: new Headers(sim.headers || {}),
+    } as ResponseType),
+    mockRejectedValue: (sim: Partial<ResponseType>) => spy.mockResolvedValueOnce({
+      responseType: 'error',
+      status: 500,
+      ...sim,
+      headers: new Headers(sim.headers || {}),
+    } as ResponseType),
+    mockRejectedValueOnce: (sim: Partial<ResponseType>) => spy.mockResolvedValueOnce({
+      responseType: 'error',
+      ...sim,
+      headers: new Headers(sim.headers || {}),
+    } as ResponseType),
+    spy,
+  };
+}
+
 export const jestConfig: JestConfigWithTsJest = {
   verbose: true,
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/js-with-ts-legacy',
   testEnvironment: 'node',
   testRegex: '(\\.|/)(test|spec)\\.[jt]sx?$',
   setupFilesAfterEnv: [path.resolve(__dirname, '../build/afterAll.js')],


### PR DESCRIPTION
Depends on https://github.com/gas-buddy/service/pull/334

Deprecating `mockServiceCall` in favor of `mockServiceClientCall` and updating tests accordingly.